### PR TITLE
Add support for custom application icons

### DIFF
--- a/client/src/main/active.ts
+++ b/client/src/main/active.ts
@@ -18,6 +18,7 @@ export default class Active {
   private suggestion: string = "";
 
   app: string = "";
+  icon?: string;
   customCommands: any[] = [];
   customHints: any[] = [];
   customWords: any[] = [];
@@ -384,14 +385,18 @@ export default class Active {
         ? this.languageSwitcherLanguage
         : filenameToLanguage(filename);
 
+    const icon = plugin?.icon;
+
     const send =
       force ||
       app != this.app ||
+      icon != this.icon ||
       filename != this.filename ||
       language != this.language ||
       sourceAvailable != this.sourceAvailable;
 
     this.app = app;
+    this.icon = icon;
     this.filename = filename;
     this.language = language;
     this.sourceAvailable = sourceAvailable;
@@ -401,6 +406,7 @@ export default class Active {
       this.bridge.setState(
         {
           app: this.app,
+          icon: this.icon,
           dictateMode: this.dictateMode,
           filename: this.filename,
           firstPartyPluginAvailable: this.firstPartyPluginAvailable(),

--- a/client/src/main/app.ts
+++ b/client/src/main/app.ts
@@ -167,7 +167,8 @@ export default class App {
       mainWindow,
       miniModeWindow,
       pluginManager,
-      stream
+      stream,
+      log
     );
 
     await custom.start();

--- a/client/src/main/ipc/plugin-manager.ts
+++ b/client/src/main/ipc/plugin-manager.ts
@@ -11,6 +11,7 @@ export type Plugin = {
   lastActive: number;
   websocket: WebSocket;
   match?: string;
+  icon?: string;
 };
 
 export default class PluginManager {
@@ -35,10 +36,16 @@ export default class PluginManager {
     this.plugins = result;
   }
 
-  private updatePlugin(websocket: WebSocket, id: string, app: string, match?: string) {
+  private updatePlugin(websocket: WebSocket, id: string, app: string, match?: string, icon?: string) {
     const plugin = this.fromId(id);
     if (plugin) {
       plugin.websocket = websocket;
+
+      // only update the icon if it has a value. an empty string clears the
+      // custom icon.
+      if (icon != undefined) {
+        plugin.icon = icon;
+      }
     } else {
       if (app == "intellij") {
         app = "jetbrains";
@@ -49,6 +56,7 @@ export default class PluginManager {
         app,
         websocket,
         match,
+        icon,
         lastActive: Date.now(),
         lastHeartbeat: Date.now(),
       });
@@ -148,8 +156,8 @@ export default class PluginManager {
     });
   }
 
-  updateActive(websocket: WebSocket, id: string, app: string, match?: string) {
-    this.updatePlugin(websocket, id, app, match);
+  updateActive(websocket: WebSocket, id: string, app: string, match?: string, icon?: string) {
+    this.updatePlugin(websocket, id, app, match, icon);
     this.fromId(id)!.lastActive = Date.now();
   }
 

--- a/client/src/main/ipc/plugin-manager.ts
+++ b/client/src/main/ipc/plugin-manager.ts
@@ -42,7 +42,7 @@ export default class PluginManager {
       plugin.websocket = websocket;
 
       // only update the icon if it has a value. an empty string clears the
-      // custom icon.
+      // custom icon
       if (icon != undefined) {
         plugin.icon = icon;
       }

--- a/client/src/renderer/components/indicators/active-app-indicator.tsx
+++ b/client/src/renderer/components/indicators/active-app-indicator.tsx
@@ -44,8 +44,8 @@ const apps: { [key: string]: { name: string; icon: string } } = {
 const ActiveAppIndicatorComponent: React.FC<{
   app: string;
   pluginInstalled: boolean;
-  icon: string;
-}> = ({ app, pluginInstalled, icon }) => {
+  customIcon?: string;
+}> = ({ app, pluginInstalled, customIcon }) => {
   let name = app;
   if (Object.keys(apps).includes(app)) {
     name = apps[app].name;
@@ -53,12 +53,12 @@ const ActiveAppIndicatorComponent: React.FC<{
     name = "Other";
   }
 
-  const iconSrc = icon || (Object.keys(apps).includes(app) ? apps[app].icon : windowIcon);
+  const icon = customIcon || (Object.keys(apps).includes(app) ? apps[app].icon : windowIcon);
   return (
     <div className="block text-xs drop-shadow-sm px-1.5 py-0.5 ">
       <img
         className="w-4 h-4 inline-block mr-1"
-        src={iconSrc}
+        src={icon}
         alt={name}
         style={{ marginTop: "-2px" }}
       />{" "}
@@ -70,5 +70,5 @@ const ActiveAppIndicatorComponent: React.FC<{
 export const ActiveAppIndicator = connect((state: any) => ({
   app: state.app,
   pluginInstalled: state.pluginInstalled,
-  icon: state.icon,
+  customIcon: state.icon,
 }))(ActiveAppIndicatorComponent);

--- a/client/src/renderer/components/indicators/active-app-indicator.tsx
+++ b/client/src/renderer/components/indicators/active-app-indicator.tsx
@@ -44,7 +44,8 @@ const apps: { [key: string]: { name: string; icon: string } } = {
 const ActiveAppIndicatorComponent: React.FC<{
   app: string;
   pluginInstalled: boolean;
-}> = ({ app, pluginInstalled }) => {
+  icon: string;
+}> = ({ app, pluginInstalled, icon }) => {
   let name = app;
   if (Object.keys(apps).includes(app)) {
     name = apps[app].name;
@@ -52,12 +53,12 @@ const ActiveAppIndicatorComponent: React.FC<{
     name = "Other";
   }
 
-  const icon = Object.keys(apps).includes(app) ? apps[app].icon : windowIcon;
+  const iconSrc = icon || (Object.keys(apps).includes(app) ? apps[app].icon : windowIcon);
   return (
     <div className="block text-xs drop-shadow-sm px-1.5 py-0.5 ">
       <img
         className="w-4 h-4 inline-block mr-1"
-        src={icon}
+        src={iconSrc}
         alt={name}
         style={{ marginTop: "-2px" }}
       />{" "}
@@ -69,4 +70,5 @@ const ActiveAppIndicatorComponent: React.FC<{
 export const ActiveAppIndicator = connect((state: any) => ({
   app: state.app,
   pluginInstalled: state.pluginInstalled,
+  icon: state.icon,
 }))(ActiveAppIndicatorComponent);

--- a/client/src/renderer/state/reducer.ts
+++ b/client/src/renderer/state/reducer.ts
@@ -23,6 +23,7 @@ const initialState = {
   executeSilenceThreshold: 1,
   filename: "",
   highlighted: [],
+  icon: "",
   language: core.Language.LANGUAGE_DEFAULT,
   languageSwitcherLanguage: core.Language.LANGUAGE_NONE,
   latency: 1,

--- a/web/src/components/docs/protocol/getting-started.tsx
+++ b/web/src/components/docs/protocol/getting-started.tsx
@@ -101,6 +101,21 @@ export const Connecting: React.FC = () => (
         name. For instance, a plugin for Atom would supply a <code>match</code> of <code>atom</code>
         , so when a process containing <code>atom</code> is in the foreground.
       </li>
+      <li>
+        <code>icon</code>: The application icon to show in the main Serenade window when the
+        application is active. Must be encoded as a{" "}
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs"
+          className="text-purple-500 hover:text-purple-600 transition-colors cursor-pointer"
+          target="_blank"
+          aria-label="Data URLs - HTTP | MDN"
+          title="Data URLs - HTTP | MDN"
+        >data URL</a>
+        {" "}string and cannot be more than 20,000 characters long; ideally use a small (less than
+        48x48 pixels) version of the application icon. This field is only needed in the first{" "}
+        <code>active</code> message or whenever the icon changes (e.g. to show custom status
+        icons), and may be left out entirely if an icon isn't requred.
+      </li>
     </ul>
     <p>
       Here's a snippet that opens a WebSocket connection and sends the <code>active</code> message.

--- a/web/src/components/docs/protocol/messages-reference.tsx
+++ b/web/src/components/docs/protocol/messages-reference.tsx
@@ -25,6 +25,21 @@ export const Content = () => (
         a <code>match</code> of <code>atom</code>, so it will match any process with{" "}
         <code>atom</code> in its name.
       </li>
+      <li>
+        <code>icon</code> The application icon to show in the main Serenade window when the
+        application is active. Must be encoded as a{" "}
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs"
+          className="text-purple-500 hover:text-purple-600 transition-colors cursor-pointer"
+          target="_blank"
+          aria-label="Data URLs - HTTP | MDN"
+          title="Data URLs - HTTP | MDN"
+        >data URL</a>
+        {" "}string and cannot be more than 20,000 characters long; ideally use a small (less than
+        48x48 pixels) version of the application icon. This field is only needed in the first
+        <code>active</code> message or whenever the icon changes (e.g. to show custom status
+        icons), and may be left out entirely if an icon isn't requred.
+      </li>
     </ul>
     <Subsubheading title="heartbeat" />
     <p>Sent by a plugin to keep the connection alive with the Serenade app.</p>


### PR DESCRIPTION
**Approved Issue:** #1 

## Description

Add support for custom app icons to be passed from the plugin.

I've tested icons up to 400KB and it handled everything fine without any noticeable performance or functionality issues. The 20KB limit is far below this (and in reality icons will only be a few KBs), so I believe the fact that we're passing icons as strings through the Electron IPC will not be a problem.

## Test Plan

1. Encode a small (e.g. less than 48x48 px) icon as a [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
2. In a test plugin (e.g. using one of the [protocol examples](https://github.com/serenadeai/protocol)), pass the icon string in the initial `active` message.
3. Check that the icon is displayed as expected.

To test the icon updates, send a different icon in a new `active` message some time later.

## Pre-Review Checklist

[x] I've performed a self-review of my own code
[x] I've run the pre-commit hook to enforce code style
[x] I've added or corresponding updated tests
[x] I've run all tests and there were no failures
[x] I've updated the documentation, if applicable
