### PR TITLE
Repeat fixes

### DIFF
--- a/client/src/main/execute/insert-history.ts
+++ b/client/src/main/execute/insert-history.ts
@@ -22,13 +22,4 @@ export default class InsertHistory {
 
     return value.text;
   }
-
-  normalize(text: string, app: string) {
-    const value = this.latest(app);
-    if (value && text.startsWith(value)) {
-      text = text.substring(value.length);
-    }
-
-    return text;
-  }
 }

--- a/client/src/main/execute/native-commands.ts
+++ b/client/src/main/execute/native-commands.ts
@@ -84,9 +84,8 @@ class TypeText implements Operation {
   ) {}
 
   async execute() {
-    const text = this.insertHistory.normalize(this.text, this.active.app);
-    this.insertHistory.add(text, this.active.app);
-    await this.system.typeText(text, this.active.app);
+    this.insertHistory.add(this.text, this.active.app);
+    await this.system.typeText(this.text, this.active.app);
   }
 
   keystrokesCount(): number {

--- a/core/src/main/java/core/evaluator/CallbackEvaluator.java
+++ b/core/src/main/java/core/evaluator/CallbackEvaluator.java
@@ -84,7 +84,11 @@ public class CallbackEvaluator {
     if (e instanceof SafeToDisplayException) {
       message = e.getMessage();
     } else {
-      Logs.logError(logger, e.getMessage() != null ? e.getMessage() : "CallbackEvaluator error", e);
+      Logs.logError(
+        logger,
+        e.getMessage() != null ? e.getMessage() : "CallbackEvaluator error",
+        e
+      );
     }
 
     return Optional.of(
@@ -96,7 +100,12 @@ public class CallbackEvaluator {
             createAlternative(
               message,
               message,
-              Arrays.asList(Command.newBuilder().setType(CommandType.COMMAND_TYPE_INVALID).build())
+              Arrays.asList(
+                Command
+                  .newBuilder()
+                  .setType(CommandType.COMMAND_TYPE_INVALID)
+                  .build()
+              )
             )
           )
         )
@@ -145,12 +154,18 @@ public class CallbackEvaluator {
       .build();
   }
 
-  private CommandsResponse paste(EditorStateWithMetadata state, String directionName) {
-    NewlineNormalizer.Normalization normalization = newlineNormalizer.normalize(state);
+  private CommandsResponse paste(
+    EditorStateWithMetadata state,
+    String directionName
+  ) {
+    NewlineNormalizer.Normalization normalization = newlineNormalizer.normalize(
+      state
+    );
     state = normalization.state;
 
     String text = state.getClipboard();
-    String description = "paste" + (directionName.equals("") ? "" : " " + directionName);
+    String description =
+      "paste" + (directionName.equals("") ? "" : " " + directionName);
     String source = state.getSource();
     int cursor = state.getCursor();
     InsertDirection direction;
@@ -172,14 +187,14 @@ public class CallbackEvaluator {
       .setTextResponse(true)
       .setExecute(
         normalization.revert(
-          createAlternative(description, description, Arrays.asList(diff.toCommand()))
+          createAlternative(
+            description,
+            description,
+            Arrays.asList(diff.toCommand())
+          )
         )
       )
       .build();
-  }
-
-  private void addToHistory(String token, String transcript) {
-    history.add(token, transcript);
   }
 
   public Optional<CommandsResponse> evaluate(
@@ -193,7 +208,12 @@ public class CallbackEvaluator {
             .newBuilder(
               transcriptEvaluator.evaluate(
                 transcriptParser.parse(
-                  Arrays.asList(Alternative.newBuilder().setTranscript(request.getText()).build()),
+                  Arrays.asList(
+                    Alternative
+                      .newBuilder()
+                      .setTranscript(request.getText())
+                      .build()
+                  ),
                   state,
                   true
                 ),
@@ -209,8 +229,15 @@ public class CallbackEvaluator {
         return Optional.of(openFile(state));
       } else if (request.getType() == CallbackType.CALLBACK_TYPE_PASTE) {
         return Optional.of(paste(state, request.getText()));
-      } else if (request.getType() == CallbackType.CALLBACK_TYPE_ADD_TO_HISTORY) {
-        addToHistory(state.getToken(), request.getText());
+      } else if (
+        request.getType() == CallbackType.CALLBACK_TYPE_ADD_TO_HISTORY
+      ) {
+        history.add(state.getToken(), request.getText());
+        return Optional.empty();
+      } else if (
+        request.getType() == CallbackType.CALLBACK_TYPE_CLEAR_HISTORY
+      ) {
+        history.clear(state.getToken());
         return Optional.empty();
       }
     } catch (Exception e) {

--- a/core/src/test/java/core/BaseServiceTest.java
+++ b/core/src/test/java/core/BaseServiceTest.java
@@ -9,26 +9,16 @@ import com.google.protobuf.ByteString;
 import core.gen.rpc.Command;
 import core.gen.rpc.CommandType;
 import core.gen.rpc.CommandsResponse;
-import core.gen.rpc.CommandsResponseAlternative;
 import core.gen.rpc.EditorState;
 import core.gen.rpc.EvaluateRequest;
-import core.gen.rpc.EvaluateResponse;
 import core.gen.rpc.EvaluateTextRequest;
 import core.gen.rpc.InitializeRequest;
 import core.gen.rpc.Language;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +26,7 @@ import toolbelt.client.CoreClient;
 
 public class BaseServiceTest extends BaseTest {
 
-  private CoreClient client;
+  protected CoreClient client;
 
   @BeforeEach
   public void baseServiceBefore() {

--- a/core/src/test/java/core/visitor/CommandsVisitorTest.java
+++ b/core/src/test/java/core/visitor/CommandsVisitorTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.google.protobuf.ByteString;
 import core.BaseServiceTest;
+import core.gen.rpc.CallbackRequest;
+import core.gen.rpc.CallbackType;
 import core.gen.rpc.Command;
 import core.gen.rpc.CommandType;
 import core.gen.rpc.CommandsResponse;
-import core.gen.rpc.CommandsResponseAlternative;
 import core.gen.rpc.EditorState;
+import core.gen.rpc.EvaluateRequest;
 import core.gen.rpc.EvaluateTextRequest;
 import core.gen.rpc.Language;
 import java.util.Arrays;
@@ -17,13 +19,41 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import toolbelt.state.History;
 
 // test commands that exist in every language but can't be captured in YAML tests
 // we happen to use Python here, but none of this is Python-specific.
 public class CommandsVisitorTest extends BaseServiceTest {
 
   private Language language = Language.LANGUAGE_PYTHON;
+
+  private void clearHistory() {
+    client.send(
+      EvaluateRequest
+        .newBuilder()
+        .setCallbackRequest(
+          CallbackRequest
+            .newBuilder()
+            .setType(CallbackType.CALLBACK_TYPE_CLEAR_HISTORY)
+            .build()
+        )
+        .build()
+    );
+  }
+
+  private void addToHistory(String command) {
+    client.send(
+      EvaluateRequest
+        .newBuilder()
+        .setCallbackRequest(
+          CallbackRequest
+            .newBuilder()
+            .setType(CallbackType.CALLBACK_TYPE_ADD_TO_HISTORY)
+            .setText(command)
+            .build()
+        )
+        .build()
+    );
+  }
 
   @Test
   public void testAlternatives() {
@@ -63,27 +93,42 @@ public class CommandsVisitorTest extends BaseServiceTest {
   public void testArrowKeyDirection() {
     assertEquals(
       CommandType.COMMAND_TYPE_PRESS,
-      makeRequest("", 0, "up", language).getAlternatives(0).getCommands(1).getType()
+      makeRequest("", 0, "up", language)
+        .getAlternatives(0)
+        .getCommands(1)
+        .getType()
     );
 
     assertEquals(
       CommandType.COMMAND_TYPE_PRESS,
-      makeRequest("", 0, "down", language).getAlternatives(0).getCommands(1).getType()
+      makeRequest("", 0, "down", language)
+        .getAlternatives(0)
+        .getCommands(1)
+        .getType()
     );
 
     assertEquals(
       CommandType.COMMAND_TYPE_PRESS,
-      makeRequest("", 0, "left", language).getAlternatives(0).getCommands(1).getType()
+      makeRequest("", 0, "left", language)
+        .getAlternatives(0)
+        .getCommands(1)
+        .getType()
     );
 
     assertEquals(
       CommandType.COMMAND_TYPE_PRESS,
-      makeRequest("", 0, "right", language).getAlternatives(0).getCommands(1).getType()
+      makeRequest("", 0, "right", language)
+        .getAlternatives(0)
+        .getCommands(1)
+        .getType()
     );
 
     assertEquals(
       2,
-      makeRequest("", 0, "up two", language).getAlternatives(0).getCommands(1).getIndex()
+      makeRequest("", 0, "up two", language)
+        .getAlternatives(0)
+        .getCommands(1)
+        .getIndex()
     );
   }
 
@@ -91,7 +136,9 @@ public class CommandsVisitorTest extends BaseServiceTest {
   public void testBrokenChain() {
     assertEquals(
       "line one",
-      makeRequest("", 0, "previous tab line one", language).getExecute().getRemaining()
+      makeRequest("", 0, "previous tab line one", language)
+        .getExecute()
+        .getRemaining()
     );
   }
 
@@ -107,12 +154,20 @@ public class CommandsVisitorTest extends BaseServiceTest {
         .build(),
       Arrays.asList("go to google dot com")
     );
-    assertEquals(CommandType.COMMAND_TYPE_PRESS, r.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_PRESS,
+      r.getAlternatives(0).getCommands(0).getType()
+    );
   }
 
   @Test
   public void testChain() {
-    List<Command> r1 = makeRequest("foo\nbar\n", 0, "next line delete line", language)
+    List<Command> r1 = makeRequest(
+      "foo\nbar\n",
+      0,
+      "next line delete line",
+      language
+    )
       .getAlternatives(0)
       .getCommandsList();
 
@@ -150,7 +205,13 @@ public class CommandsVisitorTest extends BaseServiceTest {
 
   @Test
   public void testCopy() {
-    assertCommandType("def foo():", 4, "copy", language, CommandType.COMMAND_TYPE_PRESS);
+    assertCommandType(
+      "def foo():",
+      4,
+      "copy",
+      language,
+      CommandType.COMMAND_TYPE_PRESS
+    );
 
     Command c1 = assertCommandType(
       "def foo():",
@@ -218,14 +279,23 @@ public class CommandsVisitorTest extends BaseServiceTest {
 
   @Test
   public void testCut() {
-    assertCommandType("def foo():", 4, "cut", language, CommandType.COMMAND_TYPE_PRESS);
+    assertCommandType(
+      "def foo():",
+      4,
+      "cut",
+      language,
+      CommandType.COMMAND_TYPE_PRESS
+    );
 
     List<Command> c1 = assertCommandTypes(
       "foo bar\n",
       0,
       "cut word",
       language,
-      Arrays.asList(CommandType.COMMAND_TYPE_COPY, CommandType.COMMAND_TYPE_DIFF)
+      Arrays.asList(
+        CommandType.COMMAND_TYPE_COPY,
+        CommandType.COMMAND_TYPE_DIFF
+      )
     );
 
     assertEquals("foo", c1.get(0).getText());
@@ -234,8 +304,20 @@ public class CommandsVisitorTest extends BaseServiceTest {
 
   @Test
   public void testDictateMode() {
-    assertCommandType("", 0, "dictate mode", language, CommandType.COMMAND_TYPE_START_DICTATE);
-    assertCommandType("", 0, "stop dictating", language, CommandType.COMMAND_TYPE_STOP_DICTATE);
+    assertCommandType(
+      "",
+      0,
+      "dictate mode",
+      language,
+      CommandType.COMMAND_TYPE_START_DICTATE
+    );
+    assertCommandType(
+      "",
+      0,
+      "stop dictating",
+      language,
+      CommandType.COMMAND_TYPE_STOP_DICTATE
+    );
     EditorState nonPluginState = EditorState
       .newBuilder()
       .setApplication("")
@@ -279,7 +361,10 @@ public class CommandsVisitorTest extends BaseServiceTest {
   @Test
   public void testFocus() {
     CommandsResponse r = makeRequest("", 0, "focus atom", language);
-    assertEquals(CommandType.COMMAND_TYPE_FOCUS, r.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_FOCUS,
+      r.getAlternatives(0).getCommands(0).getType()
+    );
     assertEquals("atom", r.getAlternatives(0).getCommands(0).getText());
   }
 
@@ -287,13 +372,24 @@ public class CommandsVisitorTest extends BaseServiceTest {
   public void testForwardDelete() {
     CommandsResponse r = makeRequest("", 0, "forward delete", language);
     assertEquals(1, r.getAlternatives(0).getCommandsList().size());
-    assertEquals("forwarddelete", r.getAlternatives(0).getCommands(0).getText());
-    assertEquals(CommandType.COMMAND_TYPE_PRESS, r.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      "forwarddelete",
+      r.getAlternatives(0).getCommands(0).getText()
+    );
+    assertEquals(
+      CommandType.COMMAND_TYPE_PRESS,
+      r.getAlternatives(0).getCommands(0).getType()
+    );
   }
 
   @Test
   public void testGoToWordChain() {
-    CommandsResponse r = makeRequest("foo bar baz", 0, "next word paste", language);
+    CommandsResponse r = makeRequest(
+      "foo bar baz",
+      0,
+      "next word paste",
+      language
+    );
     assertEquals(2, r.getAlternatives(0).getCommandsList().size());
   }
 
@@ -304,7 +400,10 @@ public class CommandsVisitorTest extends BaseServiceTest {
       Arrays.asList("system hello world")
     );
 
-    assertEquals(CommandType.COMMAND_TYPE_INSERT, r.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_INSERT,
+      r.getAlternatives(0).getCommands(0).getType()
+    );
     assertEquals("hello world", r.getAlternatives(0).getCommands(0).getText());
   }
 
@@ -350,17 +449,50 @@ public class CommandsVisitorTest extends BaseServiceTest {
       CommandType.COMMAND_TYPE_LANGUAGE_MODE
     );
 
-    assertCommandType("", 0, "language python", language, CommandType.COMMAND_TYPE_LANGUAGE_MODE);
-    assertCommandType("", 0, "python mode", language, CommandType.COMMAND_TYPE_LANGUAGE_MODE);
-    assertCommandType("", 0, "rust mode", language, CommandType.COMMAND_TYPE_LANGUAGE_MODE);
-    assertCommandType("", 0, "c sharp mode", language, CommandType.COMMAND_TYPE_LANGUAGE_MODE);
-    assertCommandType("", 0, "go mode", language, CommandType.COMMAND_TYPE_LANGUAGE_MODE);
+    assertCommandType(
+      "",
+      0,
+      "language python",
+      language,
+      CommandType.COMMAND_TYPE_LANGUAGE_MODE
+    );
+    assertCommandType(
+      "",
+      0,
+      "python mode",
+      language,
+      CommandType.COMMAND_TYPE_LANGUAGE_MODE
+    );
+    assertCommandType(
+      "",
+      0,
+      "rust mode",
+      language,
+      CommandType.COMMAND_TYPE_LANGUAGE_MODE
+    );
+    assertCommandType(
+      "",
+      0,
+      "c sharp mode",
+      language,
+      CommandType.COMMAND_TYPE_LANGUAGE_MODE
+    );
+    assertCommandType(
+      "",
+      0,
+      "go mode",
+      language,
+      CommandType.COMMAND_TYPE_LANGUAGE_MODE
+    );
   }
 
   @Test
   public void testLaunch() {
     CommandsResponse r = makeRequest("", 0, "launch atom", language);
-    assertEquals(CommandType.COMMAND_TYPE_LAUNCH, r.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_LAUNCH,
+      r.getAlternatives(0).getCommands(0).getType()
+    );
     assertEquals("atom", r.getAlternatives(0).getCommands(0).getText());
   }
 
@@ -378,7 +510,10 @@ public class CommandsVisitorTest extends BaseServiceTest {
       0,
       "inspect parameter",
       language,
-      Arrays.asList(CommandType.COMMAND_TYPE_DIFF, CommandType.COMMAND_TYPE_DEBUGGER_SHOW_HOVER)
+      Arrays.asList(
+        CommandType.COMMAND_TYPE_DIFF,
+        CommandType.COMMAND_TYPE_DEBUGGER_SHOW_HOVER
+      )
     );
 
     assertEquals(8, c.get(0).getCursor());
@@ -389,7 +524,10 @@ public class CommandsVisitorTest extends BaseServiceTest {
         0,
         "show value of a",
         language,
-        Arrays.asList(CommandType.COMMAND_TYPE_DIFF, CommandType.COMMAND_TYPE_DEBUGGER_SHOW_HOVER)
+        Arrays.asList(
+          CommandType.COMMAND_TYPE_DIFF,
+          CommandType.COMMAND_TYPE_DEBUGGER_SHOW_HOVER
+        )
       );
 
     assertEquals(8, c.get(0).getCursor());
@@ -397,14 +535,34 @@ public class CommandsVisitorTest extends BaseServiceTest {
 
   @Test
   public void testNativeDiff() {
-    CommandsResponse r1 = makeRequest("", 0, Arrays.asList("type hello"), language);
-    assertEquals(1, r1.getAlternatives(0).getCommands(0).getChangesList().size());
-    assertEquals(CommandType.COMMAND_TYPE_DIFF, r1.getAlternatives(0).getCommands(0).getType());
+    CommandsResponse r1 = makeRequest(
+      "",
+      0,
+      Arrays.asList("type hello"),
+      language
+    );
+    assertEquals(
+      1,
+      r1.getAlternatives(0).getCommands(0).getChangesList().size()
+    );
+    assertEquals(
+      CommandType.COMMAND_TYPE_DIFF,
+      r1.getAlternatives(0).getCommands(0).getType()
+    );
     assertEquals(5, r1.getAlternatives(0).getCommands(0).getCursor());
     assertEquals("hello", r1.getAlternatives(0).getCommands(0).getSource());
-    assertEquals("hello", r1.getAlternatives(0).getCommands(0).getChanges(0).getSubstitution());
-    assertEquals(0, r1.getAlternatives(0).getCommands(0).getChanges(0).getStart());
-    assertEquals(0, r1.getAlternatives(0).getCommands(0).getChanges(0).getStop());
+    assertEquals(
+      "hello",
+      r1.getAlternatives(0).getCommands(0).getChanges(0).getSubstitution()
+    );
+    assertEquals(
+      0,
+      r1.getAlternatives(0).getCommands(0).getChanges(0).getStart()
+    );
+    assertEquals(
+      0,
+      r1.getAlternatives(0).getCommands(0).getChanges(0).getStop()
+    );
 
     CommandsResponse r2 = makeRequest(
       "today is is tuesday",
@@ -413,12 +571,27 @@ public class CommandsVisitorTest extends BaseServiceTest {
       language
     );
 
-    assertEquals(CommandType.COMMAND_TYPE_DIFF, r2.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_DIFF,
+      r2.getAlternatives(0).getCommands(0).getType()
+    );
     assertEquals(6, r2.getAlternatives(0).getCommands(0).getCursor());
-    assertEquals("today is tuesday", r2.getAlternatives(0).getCommands(0).getSource());
-    assertEquals("", r2.getAlternatives(0).getCommands(0).getChanges(0).getSubstitution());
-    assertEquals(6, r2.getAlternatives(0).getCommands(0).getChanges(0).getStart());
-    assertEquals(9, r2.getAlternatives(0).getCommands(0).getChanges(0).getStop());
+    assertEquals(
+      "today is tuesday",
+      r2.getAlternatives(0).getCommands(0).getSource()
+    );
+    assertEquals(
+      "",
+      r2.getAlternatives(0).getCommands(0).getChanges(0).getSubstitution()
+    );
+    assertEquals(
+      6,
+      r2.getAlternatives(0).getCommands(0).getChanges(0).getStart()
+    );
+    assertEquals(
+      9,
+      r2.getAlternatives(0).getCommands(0).getChanges(0).getStop()
+    );
 
     CommandsResponse r3 = makeRequest(
       "one\ntwo\nthree",
@@ -427,7 +600,10 @@ public class CommandsVisitorTest extends BaseServiceTest {
       language
     );
 
-    assertEquals(CommandType.COMMAND_TYPE_DIFF, r3.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_DIFF,
+      r3.getAlternatives(0).getCommands(0).getType()
+    );
     assertEquals(7, r3.getAlternatives(0).getCommands(0).getCursor());
   }
 
@@ -476,7 +652,10 @@ public class CommandsVisitorTest extends BaseServiceTest {
     );
 
     assertEquals(2, r.getAlternativesList().size());
-    assertEquals(CommandType.COMMAND_TYPE_PRESS, r.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_PRESS,
+      r.getAlternatives(0).getCommands(0).getType()
+    );
   }
 
   @Test
@@ -507,19 +686,30 @@ public class CommandsVisitorTest extends BaseServiceTest {
       Arrays.asList("paste")
     );
 
-    assertEquals(CommandType.COMMAND_TYPE_PRESS, r.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_PRESS,
+      r.getAlternatives(0).getCommands(0).getType()
+    );
   }
 
   @Test
   public void testPressQuantifier() {
     CommandsResponse r2 = makeRequest("", 0, "press up two times", language);
     assertEquals(2, r2.getAlternatives(0).getCommandsList().size());
-    assertEquals(CommandType.COMMAND_TYPE_PRESS, r2.getAlternatives(0).getCommands(0).getType());
+    assertEquals(
+      CommandType.COMMAND_TYPE_PRESS,
+      r2.getAlternatives(0).getCommands(0).getType()
+    );
   }
 
   @Test
   public void testQuantifier() {
-    CommandsResponse response = makeRequest("foo\nbar", 0, "delete line two times", language);
+    CommandsResponse response = makeRequest(
+      "foo\nbar",
+      0,
+      "delete line two times",
+      language
+    );
     assertEquals(
       CommandType.COMMAND_TYPE_DIFF,
       response.getAlternatives(0).getCommands(0).getType()
@@ -533,56 +723,78 @@ public class CommandsVisitorTest extends BaseServiceTest {
 
   @Test
   public void testRepeat() {
-    // local environments use the in-memory data store, but the test process and the core
-    // process don't share memory, so this test won't work
-    if (System.getenv("IN_MEMORY") != null && System.getenv("IN_MEMORY").equals("1")) {
-      return;
-    }
+    clearHistory();
+    addToHistory("new tab");
+    assertCommandType(
+      "",
+      0,
+      "repeat",
+      language,
+      CommandType.COMMAND_TYPE_CREATE_TAB
+    );
 
-    History history = component.history();
-
-    history.clear(token);
-    history.add(token, "new tab");
-    assertCommandType("", 0, "repeat", language, CommandType.COMMAND_TYPE_CREATE_TAB);
-
-    history.clear(token);
-    history.add(token, "new tab");
-    history.add(token, "close tab");
-    assertCommandType("", 0, "repeat", language, CommandType.COMMAND_TYPE_CLOSE_TAB);
-    assertCommandType("", 0, "repeat new", language, CommandType.COMMAND_TYPE_CREATE_TAB);
-    assertCommandType("", 0, "repeat close", language, CommandType.COMMAND_TYPE_CLOSE_TAB);
-    assertCommandType("", 0, "repeat", language, CommandType.COMMAND_TYPE_CLOSE_TAB);
+    clearHistory();
+    addToHistory("new tab");
+    addToHistory("close tab");
+    assertCommandType(
+      "",
+      0,
+      "repeat",
+      language,
+      CommandType.COMMAND_TYPE_CLOSE_TAB
+    );
+    assertCommandType(
+      "",
+      0,
+      "repeat new",
+      language,
+      CommandType.COMMAND_TYPE_CREATE_TAB
+    );
+    assertCommandType(
+      "",
+      0,
+      "repeat close",
+      language,
+      CommandType.COMMAND_TYPE_CLOSE_TAB
+    );
+    assertCommandType(
+      "",
+      0,
+      "repeat",
+      language,
+      CommandType.COMMAND_TYPE_CLOSE_TAB
+    );
 
     // test we don't loop infinitely.
-    history.clear(token);
-    history.add(token, "change word to bar");
-    history.add(token, "end of line repeat change");
+    clearHistory();
+    addToHistory("change word to bar");
+    addToHistory("end of line repeat change");
     assertCommandTypes(
       "foo\n",
       1,
       "end of line repeat change",
       language,
-      Arrays.asList(CommandType.COMMAND_TYPE_DIFF, CommandType.COMMAND_TYPE_DIFF)
+      Arrays.asList(
+        CommandType.COMMAND_TYPE_DIFF,
+        CommandType.COMMAND_TYPE_DIFF
+      )
     );
   }
 
   @Test
   public void testRepeatQuantifier() {
-    // see testRepeat
-    if (System.getenv("IN_MEMORY") != null && System.getenv("IN_MEMORY").equals("1")) {
-      return;
-    }
-
-    History history = component.history();
-    history.clear(token);
-    history.add(token, "delete character");
+    clearHistory();
+    addToHistory("delete character");
 
     assertCommandTypes(
       "abcdefghijklmn\n",
       3,
       "repeat twice",
       language,
-      Arrays.asList(CommandType.COMMAND_TYPE_DIFF, CommandType.COMMAND_TYPE_DIFF)
+      Arrays.asList(
+        CommandType.COMMAND_TYPE_DIFF,
+        CommandType.COMMAND_TYPE_DIFF
+      )
     );
 
     assertCommandTypes(
@@ -590,7 +802,10 @@ public class CommandsVisitorTest extends BaseServiceTest {
       3,
       "repeat delete twice",
       language,
-      Arrays.asList(CommandType.COMMAND_TYPE_DIFF, CommandType.COMMAND_TYPE_DIFF)
+      Arrays.asList(
+        CommandType.COMMAND_TYPE_DIFF,
+        CommandType.COMMAND_TYPE_DIFF
+      )
     );
 
     assertCommandTypes(
@@ -644,11 +859,17 @@ public class CommandsVisitorTest extends BaseServiceTest {
   public void testSwitchWindow() {
     assertEquals(
       CommandType.COMMAND_TYPE_PRESS,
-      makeRequest("", 0, "switch windows", language).getAlternatives(0).getCommands(0).getType()
+      makeRequest("", 0, "switch windows", language)
+        .getAlternatives(0)
+        .getCommands(0)
+        .getType()
     );
     assertEquals(
       CommandType.COMMAND_TYPE_PRESS,
-      makeRequest("", 0, "switch window", language).getAlternatives(0).getCommands(0).getType()
+      makeRequest("", 0, "switch window", language)
+        .getAlternatives(0)
+        .getCommands(0)
+        .getType()
     );
   }
 
@@ -672,7 +893,13 @@ public class CommandsVisitorTest extends BaseServiceTest {
     );
     assertEquals(4, c2.getIndex());
 
-    Command c3 = assertCommandType("", 0, "Tab 3", language, CommandType.COMMAND_TYPE_SWITCH_TAB);
+    Command c3 = assertCommandType(
+      "",
+      0,
+      "Tab 3",
+      language,
+      CommandType.COMMAND_TYPE_SWITCH_TAB
+    );
     assertEquals(3, c3.getIndex());
   }
 
@@ -728,13 +955,19 @@ public class CommandsVisitorTest extends BaseServiceTest {
     // use two
     assertEquals(
       CommandType.COMMAND_TYPE_INVALID,
-      response.getAlternatives(response.getAlternativesList().size() - 2).getCommands(0).getType()
+      response
+        .getAlternatives(response.getAlternativesList().size() - 2)
+        .getCommands(0)
+        .getType()
     );
 
     // type hello
     assertNotEquals(
       CommandType.COMMAND_TYPE_INVALID,
-      response.getAlternatives(response.getAlternativesList().size() - 1).getCommands(0).getType()
+      response
+        .getAlternatives(response.getAlternativesList().size() - 1)
+        .getCommands(0)
+        .getType()
     );
   }
 }

--- a/toolbelt/src/main/proto/core.proto
+++ b/toolbelt/src/main/proto/core.proto
@@ -10,6 +10,7 @@ enum CallbackType {
     CALLBACK_TYPE_OPEN_FILE = 2;
     CALLBACK_TYPE_PASTE = 3;
     CALLBACK_TYPE_ADD_TO_HISTORY = 4;
+    CALLBACK_TYPE_CLEAR_HISTORY = 5;
 }
 
 enum CommandType {


### PR DESCRIPTION
## Description

Added grpc calls to enable unit tests for repeat with in-memory user state. Removed normalization that was preventing repeat from working with commands that use the insert-history.

## Test Plan

Running core unit tests. Running system insert and repeat from the client. Day-to-day usage in a variety of apps.

## Pre-Review Checklist

[ x ] I've performed a self-review of my own code
[ x ] I've run the pre-commit hook to enforce code style
[ x ] I've added or corresponding updated tests
[ x ] I've run all tests and there were no failures
[ x ] I've updated the documentation, if applicable
